### PR TITLE
Add device pairing example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /vendor
+bin/

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gozwave/gozw"
 	switchbinary "github.com/gozwave/gozw/cc/switch-binary"
-	"github.com/davecgh/go-spew/spew"
 )
 
 var networkKey = []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
@@ -17,7 +17,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer client.Shutdown()
+	defer func() {
+		if err := client.Shutdown(); err != nil {
+			log.Fatal(err)
+		}
+	}()
 
 	spew.Dump(client.Controller)
 

--- a/examples/pairing/main.go
+++ b/examples/pairing/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gozwave/gozw"

--- a/examples/pairing/main.go
+++ b/examples/pairing/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/gozwave/gozw"
+)
+
+var networkKey = []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+func main() {
+	client, err := gozw.NewDefaultClient("/tmp/data.db", "/dev/tty.usbmodem1431", 115200, networkKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := client.Shutdown(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	spew.Dump(client.Controller)
+
+	for _, node := range client.Nodes() {
+		fmt.Println(node.String())
+	}
+
+	fmt.Println("removing node, put device in unpairing mode")
+	if _, err := client.RemoveNode(); err != nil {
+		log.Fatalf("failed to remove node: %v", err)
+	}
+
+	fmt.Println("adding node, put device in pairing mode")
+	node, err := client.AddNode()
+	if err != nil {
+		log.Fatalf("failed to add node: %v", err)
+	}
+
+	fmt.Println(node.String())
+	// node, err := client.Node(2)
+	// if err != nil {
+	// 	log.Fatalf("retrieve node: %v", err)
+	// }
+
+	// err = node.SendCommand(&switchbinary.Get{})
+	// if err != nil {
+	// 	log.Fatalf("send command: %v", err)
+	// }
+
+	time.Sleep(2 * time.Second)
+
+}

--- a/examples/pairing/main.go
+++ b/examples/pairing/main.go
@@ -40,16 +40,4 @@ func main() {
 	}
 
 	fmt.Println(node.String())
-	// node, err := client.Node(2)
-	// if err != nil {
-	// 	log.Fatalf("retrieve node: %v", err)
-	// }
-
-	// err = node.SendCommand(&switchbinary.Get{})
-	// if err != nil {
-	// 	log.Fatalf("send command: %v", err)
-	// }
-
-	time.Sleep(2 * time.Second)
-
 }


### PR DESCRIPTION
Run with `go run example/pairing/main.go`. Make sure you have a zwave device on hand that you can put into the correct mode.

Example node paired with this script:

```
Node 22:
  Failing? false
  Is listening? false
  Is secure? true
  Basic device class: Routing Slave (0x4)
  Generic device class: Sensor Notification (0x7)
  Specific device class: Notification Sensor (0x1)
  Manufacturer ID: 0x10f
  Product Type ID: 0x801
  Product ID: 0x2001
  Supported command classes:
    - Command Class Basic (v1) (secure)
    - Command Class Alarm (v5) (secure)
    - Command Class Application Status (v1)
    - Command Class Sensor Alarm (v1) (secure)
    - Command Class Security (v1)
    - Command Class Manufacturer Specific (v2)
    - Command Class Association Group Info (v1)
    - Command Class Association (v2) (secure)
    - Command Class CRC16 Encap (v1)
    - Command Class Sensor Binary (v1) (secure)
    - Command Class Sensor Multilevel (v8)
    - Command Class Firmware Update Md (v3)
    - Command Class Configuration (v1) (secure)
    - Command Class Multi Instance Association (v2) (secure)
    - Command Class Z-Wave+ Info (v2)
    - Command Class Version (v2)
    - Command Class Device Reset Locally (v1) (secure)
    - Command Class Powerlevel (v1)
    - Command Class Wake Up (v2) (secure)
    - Command Class Battery (v1)
```