### PR TITLE
add factory reset functionality

### DIFF
--- a/examples/basic/factory_reset.go
+++ b/examples/basic/factory_reset.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/gozwave/gozw"
+)
+
+var networkKey = []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+func main() {
+	devicePath := "/dev/ttyACM0"
+	if p := os.Getenv("GOZW_DEVICE_PATH"); p != "" {
+		devicePath = p
+	}
+	client, err := gozw.NewDefaultClient("/tmp/data.db", devicePath, 115200, networkKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := client.Shutdown(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	spew.Dump(client.Controller)
+
+	for _, node := range client.Nodes() {
+		fmt.Println(node.String())
+	}
+
+	client.FactoryReset()
+
+	for _, node := range client.Nodes() {
+		fmt.Println(node.String())
+	}
+
+	time.Sleep(2 * time.Second)
+
+}

--- a/gozw.go
+++ b/gozw.go
@@ -227,6 +227,11 @@ func (c *Client) Shutdown() error {
 	return nil
 }
 
+func (c *Client) FactoryReset() error {
+	c.serialAPI.FactoryReset()
+	return nil
+}
+
 func (c *Client) AddNode() (*Node, error) {
 	newNodeInfo, err := c.serialAPI.AddNode()
 	if err != nil {

--- a/serialapi/factory_reset.go
+++ b/serialapi/factory_reset.go
@@ -1,0 +1,24 @@
+package serialapi
+
+import (
+	"time"
+
+	"github.com/gozwave/gozw/protocol"
+	"github.com/gozwave/gozw/session"
+)
+
+// FactoryReset will clear the network configuration and Soft Reset the controller
+// WARNING: This can (and often will) cause the device to get a new USB address,
+// rendering the serial port's file descriptor invalid.
+func (s *Layer) FactoryReset() {
+
+	request := &session.Request{
+		FunctionID: protocol.FnSetDefault,
+		HasReturn:  false,
+	}
+
+	s.sessionLayer.MakeRequest(request)
+
+	time.Sleep(1500 * time.Millisecond)
+
+}

--- a/serialapi/factory_reset.go
+++ b/serialapi/factory_reset.go
@@ -3,6 +3,7 @@ package serialapi
 import (
 	"time"
 
+	"github.com/gozwave/gozw/frame"
 	"github.com/gozwave/gozw/protocol"
 	"github.com/gozwave/gozw/session"
 )
@@ -11,14 +12,16 @@ import (
 // WARNING: This can (and often will) cause the device to get a new USB address,
 // rendering the serial port's file descriptor invalid.
 func (s *Layer) FactoryReset() {
-
 	request := &session.Request{
-		FunctionID: protocol.FnSetDefault,
-		HasReturn:  false,
+		FunctionID:       protocol.FnSetDefault,
+		HasReturn:        false,
+		ReceivesCallback: true,
+		Callback: func(f frame.Frame) {
+			return
+		},
 	}
 
 	s.sessionLayer.MakeRequest(request)
 
 	time.Sleep(1500 * time.Millisecond)
-
 }

--- a/serialapi/layer.go
+++ b/serialapi/layer.go
@@ -25,6 +25,7 @@ type ILayer interface {
 	RemoveFailedNode(nodeID byte) (removed bool, err error)
 	RequestNodeInfo(nodeInfo byte) (*NodeInfoFrame, error)
 	SoftReset()
+	FactoryReset()
 }
 
 // Layer contains the serial api layer.

--- a/serialapi/layer.go
+++ b/serialapi/layer.go
@@ -3,9 +3,9 @@ package serialapi
 import (
 	"context"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gozwave/gozw/protocol"
 	"github.com/gozwave/gozw/session"
-	"github.com/davecgh/go-spew/spew"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
This PR implements a wrapper around `SetDefault`, which restores the zwave device network configuration to its default, effectively factory resetting it.

https://www.generationrobots.com/media/Domotique/Z-Way-developers-documentation.pdf