### PR TITLE
Ss prune nodes

### DIFF
--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -22,6 +22,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	defer func() {
 		if err := client.Shutdown(); err != nil {
 			log.Fatal(err)

--- a/examples/pairing/prune.go
+++ b/examples/pairing/prune.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/gozwave/gozw"
+)
+
+var networkKey = []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+func main() {
+	devicePath := "/dev/tty.usbmodem141101"
+	if p := os.Getenv("GOZW_DEVICE_PATH"); p != "" {
+		devicePath = p
+	}
+	fmt.Println("Adding the same node twice will update the network appropriately, but the client will keep duplicate entries of the nodes in its internal map. PruneNodes removes the node from the client's internal map and DB")
+
+	client, err := gozw.NewDefaultClient("/tmp/data.db", devicePath, 115200, networkKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := client.Shutdown(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	spew.Dump(client.Controller)
+
+	for _, node := range client.Nodes() {
+		fmt.Println(node.String())
+	}
+
+	fmt.Println("removing node, put device in unpairing mode")
+	if _, err := client.RemoveNode(); err != nil {
+		log.Fatalf("failed to remove node: %v", err)
+	}
+	fmt.Println("-----------------------------------------")
+
+	fmt.Println("adding node, put device in pairing mode")
+	_, err = client.AddNode()
+	if err != nil {
+		log.Fatalf("failed to add node: %v", err)
+	}
+
+	fmt.Printf("%+v", client.Nodes())
+	client.PruneNodes()
+	fmt.Printf("%+v", client.Nodes())
+	fmt.Println("=========================================")
+
+	fmt.Println("removing node, put device in unpairing mode")
+	if _, err = client.RemoveNode(); err != nil {
+		log.Fatalf("failed to remove node: %v", err)
+	}
+	fmt.Println("-----------------------------------------")
+
+	fmt.Println("adding node, put device in pairing mode")
+	_, err = client.AddNode()
+	if err != nil {
+		log.Fatalf("failed to add node: %v", err)
+	}
+
+	fmt.Printf("%+v", client.Nodes())
+	client.PruneNodes()
+	fmt.Printf("%+v", client.Nodes())
+	fmt.Println("=========================================")
+}

--- a/gozw.go
+++ b/gozw.go
@@ -203,20 +203,20 @@ func contains(s []byte, e byte) bool {
 func (c *Client) PruneNodes() error {
 	dbNodes := c.Nodes()
 	initData, err := c.serialAPI.GetInitAppData()
-	nodeList := initData.GetNodeIDs()
-
 	if err != nil {
-		fmt.Print(err)
 		return err
 	}
+
+	nodeList := initData.GetNodeIDs()
+
 	for id, node := range dbNodes {
 		inNodeList := contains(nodeList, id)
 		if !inNodeList {
 			err = node.removeFromDb()
-			delete(c.nodes, id)
 			if err != nil {
 				return err
 			}
+			delete(c.nodes, id)
 		}
 	}
 	return nil
@@ -286,8 +286,12 @@ func (c *Client) Shutdown() error {
 
 func (c *Client) FactoryReset() error {
 	c.serialAPI.FactoryReset()
-	c.PruneNodes()
-	err := c.clearDb()
+	err := c.PruneNodes()
+	if err != nil {
+		return err
+	}
+
+	err = c.clearDb()
 	if err != nil {
 		return err
 	}
@@ -297,7 +301,11 @@ func (c *Client) FactoryReset() error {
 
 func (c *Client) AddNode() (*Node, error) {
 	newNodeInfo, err := c.serialAPI.AddNode()
-	c.PruneNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.PruneNodes()
 	if err != nil {
 		return nil, err
 	}
@@ -338,7 +346,11 @@ func (c *Client) AddNode() (*Node, error) {
 
 func (c *Client) RemoveNode() (byte, error) {
 	result, err := c.serialAPI.RemoveNode()
-	c.PruneNodes()
+	if err != nil {
+		return 0, err
+	}
+
+	err = c.PruneNodes()
 	if err != nil {
 		return 0, err
 	}

--- a/gozw.go
+++ b/gozw.go
@@ -224,7 +224,7 @@ func (c *Client) PruneNodes() error {
 
 // Node will retrieve a single node.
 func (c *Client) Node(nodeID byte) (*Node, error) {
-	if node, ok := c.nodes[nodeID]; ok {
+	if node, ok := c.Nodes()[nodeID]; ok {
 		return node, nil
 	}
 

--- a/gozw.go
+++ b/gozw.go
@@ -207,12 +207,16 @@ func (c *Client) PruneNodes() error {
 
 	if err != nil {
 		fmt.Print(err)
+		return err
 	}
 	for id, node := range dbNodes {
 		inNodeList := contains(nodeList, id)
 		if !inNodeList {
-			node.removeFromDb()
+			err = node.removeFromDb()
 			delete(c.nodes, id)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -282,6 +286,7 @@ func (c *Client) Shutdown() error {
 
 func (c *Client) FactoryReset() error {
 	c.serialAPI.FactoryReset()
+	c.PruneNodes()
 	err := c.clearDb()
 	if err != nil {
 		return err
@@ -292,6 +297,7 @@ func (c *Client) FactoryReset() error {
 
 func (c *Client) AddNode() (*Node, error) {
 	newNodeInfo, err := c.serialAPI.AddNode()
+	c.PruneNodes()
 	if err != nil {
 		return nil, err
 	}
@@ -332,6 +338,7 @@ func (c *Client) AddNode() (*Node, error) {
 
 func (c *Client) RemoveNode() (byte, error) {
 	result, err := c.serialAPI.RemoveNode()
+	c.PruneNodes()
 	if err != nil {
 		return 0, err
 	}

--- a/gozw.go
+++ b/gozw.go
@@ -190,6 +190,34 @@ func (c *Client) Nodes() map[byte]*Node {
 	return c.nodes
 }
 
+func contains(s []byte, e byte) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+// Will prune any duplicate nodes from the database
+func (c *Client) PruneNodes() error {
+	dbNodes := c.Nodes()
+	initData, err := c.serialAPI.GetInitAppData()
+	nodeList := initData.GetNodeIDs()
+
+	if err != nil {
+		fmt.Print(err)
+	}
+	for id, node := range dbNodes {
+		inNodeList := contains(nodeList, id)
+		if !inNodeList {
+			node.removeFromDb()
+			delete(c.nodes, id)
+		}
+	}
+	return nil
+}
+
 // Node will retrieve a single node.
 func (c *Client) Node(nodeID byte) (*Node, error) {
 	if node, ok := c.nodes[nodeID]; ok {

--- a/node.go
+++ b/node.go
@@ -132,6 +132,16 @@ func (n *Node) initialize() error {
 
 }
 
+func (n *Node) removeFromDb() error {
+	err := n.client.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte("nodes"))
+		err := bucket.Delete([]byte{n.NodeID})
+		return err
+	})
+
+	return err
+}
+
 func (n *Node) saveToDb() error {
 	data, err := msgpack.Marshal(n)
 	if err != nil {

--- a/node.go
+++ b/node.go
@@ -133,13 +133,11 @@ func (n *Node) initialize() error {
 }
 
 func (n *Node) removeFromDb() error {
-	err := n.client.db.View(func(tx *bolt.Tx) error {
+	return n.client.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("nodes"))
 		err := bucket.Delete([]byte{n.NodeID})
 		return err
 	})
-
-	return err
 }
 
 func (n *Node) saveToDb() error {

--- a/node.go
+++ b/node.go
@@ -22,7 +22,14 @@ import (
 	msgpack "gopkg.in/vmihailenco/msgpack.v2"
 )
 
+type GoZWNode interface {
+	loadFromDb() error
+	removeFromDb() error
+	saveToDb() error
+}
+
 type Node struct {
+	GoZWNode
 	NodeID byte
 
 	Capability          byte

--- a/serialapi/init_data.go
+++ b/serialapi/init_data.go
@@ -9,7 +9,15 @@ import (
 )
 
 // InitAppData contains data to initialize application
+type AppData interface {
+	GetAPIType() string
+	TimerFunctionsSupported() bool
+	IsPrimaryController() bool
+	GetNodeIDs() []byte
+}
+
 type InitAppData struct {
+	AppData
 	CommandID    byte
 	Version      byte
 	Capabilities byte
@@ -69,20 +77,12 @@ func (n *InitAppData) GetAPIType() string {
 
 // TimerFunctionsSupported returns whether timer functions are supported.
 func (n *InitAppData) TimerFunctionsSupported() bool {
-	if n.CommandID&0x40 == 0x40 {
-		return true
-	}
-
-	return false
+	return n.CommandID&0x40 == 0x40
 }
 
 // IsPrimaryController returns if this is the primary controller.
 func (n *InitAppData) IsPrimaryController() bool {
-	if n.CommandID&0x20 == 0x20 {
-		return false
-	}
-
-	return true
+	return !(n.CommandID&0x20 == 0x20)
 }
 
 // GetNodeIDs will return all node ids

--- a/serialapi/request_node_info.go
+++ b/serialapi/request_node_info.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gozwave/gozw/frame"
 	"github.com/gozwave/gozw/protocol"
 	"github.com/gozwave/gozw/session"
-	"github.com/davecgh/go-spew/spew"
 )
 
 // RequestNodeInfo will request info for a node.

--- a/serialapi/request_node_info.go
+++ b/serialapi/request_node_info.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 
 	"github.com/davecgh/go-spew/spew"
+	"go.uber.org/zap"
+
 	"github.com/gozwave/gozw/frame"
 	"github.com/gozwave/gozw/protocol"
 	"github.com/gozwave/gozw/session"
-	"go.uber.org/zap"
 )
 
 // RequestNodeInfo will request info for a node.

--- a/serialapi/request_node_info.go
+++ b/serialapi/request_node_info.go
@@ -2,12 +2,12 @@ package serialapi
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gozwave/gozw/frame"
 	"github.com/gozwave/gozw/protocol"
 	"github.com/gozwave/gozw/session"
+	"go.uber.org/zap"
 )
 
 // RequestNodeInfo will request info for a node.
@@ -22,7 +22,9 @@ func (s *Layer) RequestNodeInfo(nodeID byte) (*NodeInfoFrame, error) {
 		HasReturn:  true,
 		ReturnCallback: func(err error, ret *frame.Frame) bool {
 			done <- ret
-			fmt.Println(err)
+			if err != nil {
+				s.l.Error("Request Node Failed:", zap.Error(err))
+			}
 			return false
 		},
 	}


### PR DESCRIPTION
The client was keeping copies of the nodes in its internal cache and database when they were added, removed or when it was factory reset. This change adds `PruneNode` calls to each of those functions, which ensures the client's `deviceList` returned by `GetInitAppData` is the source of truth.