### PR TITLE
Bugfix AddNode lockup

### DIFF
--- a/gozw.go
+++ b/gozw.go
@@ -305,11 +305,6 @@ func (c *Client) AddNode() (*Node, error) {
 		return nil, err
 	}
 
-	err = c.PruneNodes()
-	if err != nil {
-		return nil, err
-	}
-
 	if newNodeInfo == nil {
 		return nil, errors.New("Adding node failed")
 	}


### PR DESCRIPTION
Pruning nodes while adding shouldn't be necessary, and seems to have been pruning nodes that were still being initialized.