### PR TITLE
Add pairing progress

### DIFF
--- a/frame/layer_test.go
+++ b/frame/layer_test.go
@@ -37,7 +37,7 @@ func TestGoodIncomingFrameResultsInAck(t *testing.T) {
 	frame := <-frameLayer.GetOutputChannel()
 
 	// Ensure the other goroutines have time to do their thing
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(time.Millisecond)
 
 	// Ensure ack was written back to the transport
 	assert.EqualValues(t, []byte{HeaderAck}, buf.BytesWritten.Bytes())

--- a/gozw.go
+++ b/gozw.go
@@ -373,7 +373,7 @@ func (c *Client) AddNodeWithProgress(ctx context.Context, progress chan PairingP
 	select {
 	case <-node.queryStageVersionsComplete:
 		c.l.Info("node queries complete")
-	case <-time.After(time.Second * 30):
+	case <-ctx.Done():
 		c.l.Warn("node query timeout", zap.String("node", fmt.Sprint(node.NodeID)))
 	}
 

--- a/gozw.go
+++ b/gozw.go
@@ -301,7 +301,7 @@ func (c *Client) FactoryReset() error {
 }
 
 func (c *Client) AddNode() (*Node, error) {
-	prog := make(chan PairingProgressUpdate)
+	prog := make(chan PairingProgressUpdate, 1)
 	ctx, _ := context.WithTimeout(context.Background(), 3*time.Minute) // Times out after 3 minutes
 	return c.AddNodeWithProgress(ctx, prog)
 }

--- a/node.go
+++ b/node.go
@@ -28,6 +28,14 @@ type GoZWNode interface {
 	saveToDb() error
 }
 
+type PairingProgressUpdate struct {
+	// How command classes we've heard from
+	InterviewedCommandClassCount int
+
+	// How many command classes have been reported from NIF
+	ReportedCommandClassCount int
+}
+
 type Node struct {
 	GoZWNode
 	NodeID byte
@@ -39,7 +47,8 @@ type Node struct {
 
 	Failing bool
 
-	CommandClasses cc.CommandClassSet
+	InterviewedCommandClassCount int
+	CommandClasses               cc.CommandClassSet
 
 	NetworkKeySent bool
 
@@ -240,7 +249,7 @@ func (n *Node) RequestNodeInformationFrame() error {
 
 func (n *Node) LoadCommandClassVersions() error {
 	for _, commandClass := range n.CommandClasses {
-		time.Sleep(1 * time.Second)
+		time.Sleep(100 * time.Millisecond)
 		cmd := &version.CommandClassGet{RequestedCommandClass: byte(commandClass.CommandClass)}
 		var err error
 
@@ -361,6 +370,7 @@ func (n *Node) receiveManufacturerInfo(mfgId, productTypeId, productId uint16) {
 
 func (n *Node) receiveCommandClassVersion(id cc.CommandClassID, version uint8) {
 	n.CommandClasses.SetVersion(id, version)
+	n.InterviewedCommandClassCount++
 
 	if n.CommandClasses.AllVersionsReceived() {
 		select {


### PR DESCRIPTION
This aims to provide status updates as the node reports command class versions. Originally I added a flag to the `CommandClassSet` struct that was set to true when a report was received. Unfortunately, this led to concurrency issues because the code was reading from and writing to the map simultaneously.

This also decreases some of the hard-coded timeouts, speeding up the pairing process. The downside is that this could make pairing less stable. The current values seem to be a sweet spot for the hardware we're working with.