### PR TITLE
Fix template where } was on wrong side of end statement

### DIFF
--- a/gen/templates/unmarshal-command-param.tpl
+++ b/gen/templates/unmarshal-command-param.tpl
@@ -40,8 +40,8 @@
     {{if not .IsOptional}}
     if len(payload) <= i {
       return errors.New("slice index out of bounds")
-        {{end}}}
-
+    }
+    {{end}}
 
     cmd.{{ToGoName .Name}} = binary.BigEndian.Uint16(payload[i:i+2])
     i += 2
@@ -52,6 +52,7 @@
       return nil
     }
   {{else}}
+  
 {{ template "exists" .}}
     {{if .IsNotReserved}}
       cmd.{{ToGoName .Name}} = payload[i]


### PR DESCRIPTION
Hey Guys! I was using your fork to generate some new command classes and I ran into this bug when running the generator.

When generating: `COMMAND_CLASS_METER` I was getting the following error:
`../cc/meter-v2/report.gen.go:215:5: expected declaration, found cmd (and 2 more errors)`

I updated the template and moved the closing `}` to be inside the if block.

Also while I have you as a captive audience, are you guys planning on PR'ing these recent awesome updates back to the main repo? 