### PR TITLE
Increase timeout for version-2 interviews

### DIFF
--- a/node.go
+++ b/node.go
@@ -252,8 +252,10 @@ func (n *Node) RequestNodeInformationFrame() error {
 }
 
 func (n *Node) LoadCommandClassVersions() error {
+	// These timeouts are incredibly sensitive, and adjusting
+	// them may cause the interview process to fail intermittently
 	timeoutSlow := 1 * time.Second
-	timeoutFast := 50 * time.Millisecond
+	timeoutFast := 100 * time.Millisecond
 	for _, commandClass := range n.CommandClasses {
 		interviewTimeout := timeoutSlow
 


### PR DESCRIPTION
We've observed that the pairing process goes quite a bit faster if we allow for a 100ms timeout as opposed to 50ms. This may have something to do with CAN frame timeouts