### PR TITLE
Reorder command classes during interview

### DIFF
--- a/examples/pairing/main.go
+++ b/examples/pairing/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"time"
@@ -33,15 +32,15 @@ func main() {
 	spew.Dump(client.Controller)
 
 	for _, node := range client.Nodes() {
-		fmt.Println(node.String())
+		log.Println(node.String())
 	}
 
-	fmt.Println("removing node, put device in unpairing mode")
+	log.Println("removing node, put device in unpairing mode")
 	if _, err := client.RemoveNode(); err != nil {
 		log.Fatalf("failed to remove node: %v", err)
 	}
 
-	fmt.Println("adding node, put device in pairing mode")
+	log.Println("adding node, put device in pairing mode")
 
 	progressChan := make(chan gozw.PairingProgressUpdate)
 
@@ -49,9 +48,10 @@ func main() {
 		for {
 			select {
 			case newProgress := <-progressChan:
-				fmt.Printf("pairing progress update: %d/%d", newProgress.InterviewedCommandClassCount, newProgress.ReportedCommandClassCount)
+				log.Printf("pairing progress update: %d/%d", newProgress.InterviewedCommandClassCount, newProgress.ReportedCommandClassCount)
 			case <-ctx.Done():
-				fmt.Println("pairing failed", ctx.Err())
+				log.Fatalln("pairing failed", ctx.Err())
+				return
 			}
 		}
 	}()
@@ -61,5 +61,5 @@ func main() {
 		log.Fatalf("failed to add node: %v", err)
 	}
 
-	fmt.Println(node.String())
+	log.Println(node.String())
 }

--- a/gozw.go
+++ b/gozw.go
@@ -300,7 +300,7 @@ func (c *Client) FactoryReset() error {
 
 func (c *Client) AddNode() (*Node, error) {
 	prog := make(chan PairingProgressUpdate, 1)
-	ctx, _ := context.WithTimeout(context.Background(), 1*time.Minute) // Times out after 1 minute
+	ctx, _ := context.WithTimeout(context.Background(), 3*time.Minute) // Times out after 3 minutes
 	go func() {
 		for {
 			select {

--- a/gozw.go
+++ b/gozw.go
@@ -433,6 +433,12 @@ func (c *Client) handleApplicationCommands() {
 	for {
 		select {
 		case cmd := <-c.serialAPI.ControllerCommands():
+			if len(cmd.CommandData) < 1 {
+				// This may indicate corrupt data or a parsing/interpretation error
+				c.l.Warn("received command data with a length of 0")
+				continue
+			}
+
 			switch cc.CommandClassID(cmd.CommandData[0]) {
 
 			case cc.Security:

--- a/node.go
+++ b/node.go
@@ -296,7 +296,7 @@ func isVersionCommandClassID(id cc.CommandClassID) bool {
 }
 
 func isSecurityCommandClassID(id cc.CommandClassID) bool {
-	// TODO(zacatac): These are differen command class IDs.
+	// TODO(zacatac): These are different command class IDs.
 	// Need to refer to documentation on Security2 command class.
 	//
 	// It's possible that newer devices which support

--- a/node.go
+++ b/node.go
@@ -254,9 +254,9 @@ func (n *Node) RequestNodeInformationFrame() error {
 // To optimize the interview process we'll be interview command classes
 // in the following order:
 // 1) SecurityCommandClass
-// 1) VersionCommandClass
-// 2) Remaining insecure command classes
-// 3) Secure command classes
+// 2) VersionCommandClass
+// 3) Remaining insecure command classes
+// 4) Secure command classes
 func commandClassesInOrderToInterview(set cc.CommandClassSet) []cc.CommandClassID {
 	insecure := set.ListBySecureStatus(false)
 

--- a/node.go
+++ b/node.go
@@ -346,7 +346,7 @@ func (n *Node) LoadCommandClassVersions() error {
 		waitingForVersionSince := time.Now()
 
 		// Wait until either the version has been reported, or we've waited too long
-		// 5 seconds is used to be sure any collisions (and thus CAN timeouts) are over
+		// 3.5 seconds is used to be sure any collisions (and thus CAN timeouts) are over
 		for {
 			// Check to see if this command class has been reported
 			if v := n.CommandClasses.GetVersion(commandClassID); v != 0 {

--- a/node.go
+++ b/node.go
@@ -284,29 +284,8 @@ func commandClassesInOrderToInterview(set cc.CommandClassSet) []cc.CommandClassI
 	}
 
 	secure := set.ListBySecureStatus(true)
-	fmt.Println("insecure")
-	for i, ccid := range insecure {
-		fmt.Printf("idx: %d: %s\n", i, ccid)
-	}
-	fmt.Println("secure")
-	for i, ccid := range secure {
-		fmt.Printf("idx: %d: %s\n", i, ccid)
-	}
-
 	return append(insecure, secure...)
-	// inOrder := make([]*cc.CommandClassSupport, 0, len(set))
-	// for _, ccPtr := range set {
-	// 	if ccPtr == nil {
-	// 		continue
-	// 	}
-	// 	commandc := *ccPtr
-	// 	if isVersionCommandClassID(commandc.CommandClass) {
-	// 		inOrder = append([]*cc.CommandClassSupport{&commandc}, inOrder...)
-	// 		continue
-	// 	}
-	// 	inOrder = append(inOrder)
-	// }
-	// return inOrder
+
 }
 
 func isVersionCommandClassID(id cc.CommandClassID) bool {

--- a/node.go
+++ b/node.go
@@ -353,7 +353,7 @@ func (n *Node) LoadCommandClassVersions() error {
 				break
 			}
 
-			if waitingForVersionSince.Add(time.Second * 5).Before(time.Now()) {
+			if waitingForVersionSince.Add(time.Millisecond * 3500).Before(time.Now()) {
 				n.client.l.Warn("stopped waiting for confirmation of version command class",
 					zap.String("command class ID", fmt.Sprintf("%02x", commandClassID)),
 				)

--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,135 @@
+package gozw
+
+import (
+	"testing"
+
+	"github.com/gozwave/gozw/cc"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsVersionCommandClass(t *testing.T) {
+	assert.True(t, isVersionCommandClassID(cc.CommandClassID(0x86)))
+	assert.True(t, isVersionCommandClassID(cc.Version))
+	assert.True(t, isVersionCommandClassID(cc.VersionV2))
+	assert.True(t, isVersionCommandClassID(cc.VersionV3))
+
+	assert.False(t, isVersionCommandClassID(cc.CommandClassID(0x85)))
+}
+
+func TestIsSecurityCommandClass(t *testing.T) {
+	assert.True(t, isSecurityCommandClassID(cc.CommandClassID(0x98)))
+	assert.True(t, isSecurityCommandClassID(cc.CommandClassID(0x9F)))
+	assert.True(t, isSecurityCommandClassID(cc.Security))
+	assert.True(t, isSecurityCommandClassID(cc.Security2))
+
+	assert.False(t, isSecurityCommandClassID(cc.CommandClassID(0x97)))
+}
+
+func TestCommandClassesInOrderToInterview(t *testing.T) {
+	emptySet := cc.CommandClassSet{}
+	assert.Len(t, commandClassesInOrderToInterview(emptySet), 0)
+
+	noVersionOrSecurity := cc.CommandClassSet{
+		// ccSupport defaults to insecure
+		cc.Alarm:       &cc.CommandClassSupport{},
+		cc.Antitheft:   &cc.CommandClassSupport{},
+		cc.Association: &cc.CommandClassSupport{},
+	}
+	assert.Len(t, commandClassesInOrderToInterview(noVersionOrSecurity), 3,
+		"mostly testing that we don't blow up")
+
+	justVersion := cc.CommandClassSet{
+		cc.Alarm:   &cc.CommandClassSupport{},
+		cc.Version: &cc.CommandClassSupport{},
+	}
+	assert.Len(t, commandClassesInOrderToInterview(justVersion), 2,
+		"we make no attempt to optimize the order in this case")
+
+	justSecurity := cc.CommandClassSet{
+		cc.Alarm:    &cc.CommandClassSupport{},
+		cc.Security: &cc.CommandClassSupport{},
+	}
+	assert.Len(t, commandClassesInOrderToInterview(justSecurity), 2,
+		"we make no attempt to optimize the order in this case")
+
+	var inorder []cc.CommandClassID
+
+	onlyVersionAndSecurity := cc.CommandClassSet{
+		cc.Version:  &cc.CommandClassSupport{},
+		cc.Security: &cc.CommandClassSupport{},
+	}
+	inorder = commandClassesInOrderToInterview(onlyVersionAndSecurity)
+	assert.Len(t, inorder, 2,
+		"50/50 shot at accidentally getting the order right")
+	assert.Equal(t, cc.Security, inorder[0])
+	assert.Equal(t, cc.Version, inorder[1])
+
+	oneMoreThanSecurityAndVersion := cc.CommandClassSet{
+		cc.Version:  &cc.CommandClassSupport{},
+		cc.Security: &cc.CommandClassSupport{},
+		cc.Alarm:    &cc.CommandClassSupport{},
+	}
+	inorder = commandClassesInOrderToInterview(oneMoreThanSecurityAndVersion)
+	assert.Len(t, inorder, 3, "1/3 shot at accidentally getting the order right")
+	assert.Equal(t, cc.Security, inorder[0])
+	assert.Equal(t, cc.Version, inorder[1])
+	assert.Equal(t, cc.Alarm, inorder[2])
+
+	realWorldExample := cc.CommandClassSet{
+		cc.AssociationGrpInfo:       &cc.CommandClassSupport{},
+		cc.SensorMultilevel:         &cc.CommandClassSupport{},
+		cc.Crc16Encap:               &cc.CommandClassSupport{},
+		cc.ManufacturerSpecific:     &cc.CommandClassSupport{},
+		cc.Battery:                  &cc.CommandClassSupport{},
+		cc.ZwaveplusInfo:            &cc.CommandClassSupport{},
+		cc.Powerlevel:               &cc.CommandClassSupport{},
+		cc.VersionV2:                &cc.CommandClassSupport{},
+		cc.Security:                 &cc.CommandClassSupport{},
+		cc.ApplicationStatus:        &cc.CommandClassSupport{},
+		cc.FirmwareUpdateMd:         &cc.CommandClassSupport{},
+		cc.Basic:                    &cc.CommandClassSupport{Secure: true},
+		cc.WakeUp:                   &cc.CommandClassSupport{Secure: true},
+		cc.Alarm:                    &cc.CommandClassSupport{Secure: true},
+		cc.Configuration:            &cc.CommandClassSupport{Secure: true},
+		cc.SensorAlarm:              &cc.CommandClassSupport{Secure: true},
+		cc.Association:              &cc.CommandClassSupport{Secure: true},
+		cc.MultiInstanceAssociation: &cc.CommandClassSupport{Secure: true},
+		cc.SensorBinary:             &cc.CommandClassSupport{Secure: true},
+		cc.DeviceResetLocally:       &cc.CommandClassSupport{Secure: true},
+	}
+	inorder = commandClassesInOrderToInterview(realWorldExample)
+	assert.Len(t, inorder, 20)
+	assert.Equal(t, cc.Security, inorder[0])
+	assert.Equal(t, cc.Version, inorder[1])
+
+	find := func(sl []cc.CommandClassID, ccid cc.CommandClassID) int {
+		for idx := range sl {
+			if sl[idx] == ccid {
+				return idx
+			}
+		}
+		return -1
+	}
+
+	assert.True(t, find(inorder, cc.AssociationGrpInfo) < 11, "should be in insecure section")
+	assert.True(t, find(inorder, cc.SensorMultilevel) < 11, "should be in insecure section")
+	assert.True(t, find(inorder, cc.Crc16Encap) < 11, "should be in insecure section")
+	assert.True(t, find(inorder, cc.ManufacturerSpecific) < 11, "should be in insecure section")
+	assert.True(t, find(inorder, cc.Battery) < 11, "should be in insecure section")
+	assert.True(t, find(inorder, cc.ZwaveplusInfo) < 11, "should be in insecure section")
+	assert.True(t, find(inorder, cc.Powerlevel) < 11, "should be in insecure section")
+	assert.True(t, find(inorder, cc.ApplicationStatus) < 11, "should be in insecure section")
+	assert.True(t, find(inorder, cc.FirmwareUpdateMd) < 11, "should be in insecure section")
+
+	assert.True(t, find(inorder, cc.Basic) > 10, "should be in secure section")
+	assert.True(t, find(inorder, cc.WakeUp) > 10, "should be in secure section")
+	assert.True(t, find(inorder, cc.Alarm) > 10, "should be in secure section")
+	assert.True(t, find(inorder, cc.Configuration) > 10, "should be in secure section")
+	assert.True(t, find(inorder, cc.SensorAlarm) > 10, "should be in secure section")
+	assert.True(t, find(inorder, cc.Association) > 10, "should be in secure section")
+	assert.True(t, find(inorder, cc.MultiInstanceAssociation) > 10, "should be in secure section")
+	assert.True(t, find(inorder, cc.SensorBinary) > 10, "should be in secure section")
+	assert.True(t, find(inorder, cc.DeviceResetLocally) > 10, "should be in secure section")
+
+}


### PR DESCRIPTION
This has been tested against a number of devices and does seem to decrease interview flakiness. At the very least we are able to get the version of the version command class much earlier in the process.