### PR TITLE
Listen for reported command class version instead of hard-coding timeouts

### DIFF
--- a/examples/pairing/main.go
+++ b/examples/pairing/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"time"
@@ -33,15 +32,15 @@ func main() {
 	spew.Dump(client.Controller)
 
 	for _, node := range client.Nodes() {
-		fmt.Println(node.String())
+		log.Println(node.String())
 	}
 
-	fmt.Println("removing node, put device in unpairing mode")
+	log.Println("removing node, put device in unpairing mode")
 	if _, err := client.RemoveNode(); err != nil {
 		log.Fatalf("failed to remove node: %v", err)
 	}
 
-	fmt.Println("adding node, put device in pairing mode")
+	log.Println("adding node, put device in pairing mode")
 
 	progressChan := make(chan gozw.PairingProgressUpdate)
 
@@ -49,9 +48,10 @@ func main() {
 		for {
 			select {
 			case newProgress := <-progressChan:
-				fmt.Printf("pairing progress update: %d/%d", newProgress.InterviewedCommandClassCount, newProgress.ReportedCommandClassCount)
+				log.Printf("pairing progress update: %d/%d", newProgress.InterviewedCommandClassCount, newProgress.ReportedCommandClassCount)
 			case <-ctx.Done():
-				fmt.Println("pairing failed", ctx.Err())
+				log.Fatalln("pairing failed", ctx.Err())
+				return
 			}
 		}
 	}()
@@ -61,5 +61,5 @@ func main() {
 		log.Fatalf("failed to add node: %v", err)
 	}
 
-	fmt.Println(node.String())
+	log.Println(node.String())
 }

--- a/gozw.go
+++ b/gozw.go
@@ -300,7 +300,7 @@ func (c *Client) FactoryReset() error {
 
 func (c *Client) AddNode() (*Node, error) {
 	prog := make(chan PairingProgressUpdate, 1)
-	ctx, _ := context.WithTimeout(context.Background(), 1*time.Minute) // Times out after 1 minute
+	ctx, _ := context.WithTimeout(context.Background(), 3*time.Minute) // Times out after 3 minutes
 	go func() {
 		for {
 			select {

--- a/gozw.go
+++ b/gozw.go
@@ -433,6 +433,12 @@ func (c *Client) handleApplicationCommands() {
 	for {
 		select {
 		case cmd := <-c.serialAPI.ControllerCommands():
+			if len(cmd.CommandData) < 1 {
+				// This may indicate corrupt data or a parsing/interpretation error
+				c.l.Warn("received command data with a length of 0")
+				continue
+			}
+
 			switch cc.CommandClassID(cmd.CommandData[0]) {
 
 			case cc.Security:

--- a/node.go
+++ b/node.go
@@ -346,7 +346,7 @@ func (n *Node) LoadCommandClassVersions() error {
 		waitingForVersionSince := time.Now()
 
 		// Wait until either the version has been reported, or we've waited too long
-		// 5 seconds is used to be sure any collisions (and thus CAN timeouts) are over
+		// 3.5 seconds is used to be sure any collisions (and thus CAN timeouts) are over
 		for {
 			// Check to see if this command class has been reported
 			if v := n.CommandClasses.GetVersion(commandClassID); v != 0 {

--- a/node.go
+++ b/node.go
@@ -353,7 +353,7 @@ func (n *Node) LoadCommandClassVersions() error {
 				break
 			}
 
-			if waitingForVersionSince.Add(time.Second * 5).Before(time.Now()) {
+			if waitingForVersionSince.Add(time.Millisecond * 3500).Before(time.Now()) {
 				n.client.l.Warn("stopped waiting for confirmation of version command class",
 					zap.String("command class ID", fmt.Sprintf("%02x", commandClassID)),
 				)


### PR DESCRIPTION
This change slows things down to help ensure we only request one command class version at a time. Between remaining hard-coded timeouts and possible handling errors, this seems to be the safest way to interview.